### PR TITLE
This is my test title

### DIFF
--- a/git-open-pull.go
+++ b/git-open-pull.go
@@ -17,6 +17,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
+func RenameBranch(ctx context.Context, branch string, issueNumber int) error {
+	branch = fmt.Sprintf("%s_%d", branch, issueNumber)
+	_, err = RunGit(ctx, "branch", "-m", branch)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func SetupClient(ctx context.Context, s *Settings) *github.Client {
 	if s == nil {
 		panic("missing settings")
@@ -128,9 +137,7 @@ func main() {
 			}
 			switch yn {
 			case "", "y", "Y":
-				fmt.Printf("renaming local branch %s to %s_%d\n", branch, branch, issueNumber)
-				branch = fmt.Sprintf("%s_%d", branch, issueNumber)
-				_, err = RunGit(ctx, "branch", "-m", branch)
+				err = RenameBranch(ctx, branch, issueNumber)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -139,8 +146,7 @@ func main() {
 				log.Fatalf("unknown response %q", yn)
 			}
 		} else {
-			branch = fmt.Sprintf("%s_%d", branch, issueNumber)
-			_, err = RunGit(ctx, "branch", "-m", branch)
+			err = RenameBranch(ctx, branch, issueNumber)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -200,7 +206,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if yn != "y" {
+		if strings.ToLower(yn) != "y" {
 			log.Fatal("exiting")
 		}
 	}
@@ -251,4 +257,3 @@ func main() {
 	}
 
 }
-

--- a/git-open-pull.go
+++ b/git-open-pull.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// RenameBranch renames the branch to contain the issue number
 func RenameBranch(ctx context.Context, branch string, issueNumber int) error {
 	branch = fmt.Sprintf("%s_%d", branch, issueNumber)
 	_, err := RunGit(ctx, "branch", "-m", branch)

--- a/git-open-pull.go
+++ b/git-open-pull.go
@@ -19,7 +19,7 @@ import (
 
 func RenameBranch(ctx context.Context, branch string, issueNumber int) error {
 	branch = fmt.Sprintf("%s_%d", branch, issueNumber)
-	_, err = RunGit(ctx, "branch", "-m", branch)
+	_, err := RunGit(ctx, "branch", "-m", branch)
 	if err != nil {
 		return err
 	}
@@ -69,10 +69,10 @@ func GetIssueNumber(ctx context.Context, client *github.Client, settings *Settin
 }
 
 func main() {
-	description := flag.String("description-file", "", "path to PR description file")
+	description := flag.String("description-file", "", "Path to PR description file")
 	labels := flag.String("labels", "","Comma separated PR Labels")
 	title := flag.String("title", "", "PR Title")
-	interactive := flag.Bool("interactive", true, "No command line interaction required")
+	interactive := flag.Bool("interactive", true, "Toggles interactive mode")
 
 	flag.Parse()
 

--- a/issues.go
+++ b/issues.go
@@ -47,7 +47,7 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings, in
 		gir = &github.IssueRequest{
 			Title: &title,
 			Body: &description,
-			Assignee: &settings.User
+			Assignee: &settings.User,
 		}
 
 		if labels != nil {

--- a/issues.go
+++ b/issues.go
@@ -107,7 +107,7 @@ func PopulateIssueInteractive(ctx context.Context, client *github.Client, settin
 				// log.Printf("[%d] commit %s", i, c)
 				t, b, err := CommitDetails(ctx, c)
 				if err != nil {
-					return 0, err
+					return nil, err
 				}
 				if t == "" {
 					continue

--- a/issues.go
+++ b/issues.go
@@ -31,19 +31,66 @@ func DetectIssueNumber(branch string) int {
 	return 0
 }
 
-// NewIssue creates a template, parses the template and returns the Issue number
-func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (issueNumber int, err error) {
-	labels, err := Labels(ctx, client, settings)
+func NewIssue(ctx context.Context, client *github.Client, settings *Settings, interactive bool, title, description string, labels []string) (issueNumber int, err error) {
+	var gir *github.IssueRequest
+	if interactive {
+		gir, err = PopulateIssueInteractive(ctx, client, settings, title, description, labels)
+		if err != nil {
+			log.Fatalf("Interactive issue creation failed: %v", err)
+		}
+
+	} else {
+		if title == "" {
+			log.Fatal("title cannot be empty")
+		}
+
+		gir = &github.IssueRequest{
+			Title: &title,
+		}
+
+		if description != "" {
+			gir.Body = &description
+		}
+		if labels != nil {
+			gir.Labels = &labels
+		}
+		
+		gir.Assignee = &settings.User
+
+	}
+
+	i, _, err := client.Issues.Create(ctx, settings.BaseAccount, settings.BaseRepo, gir)
 	if err != nil {
 		return 0, err
 	}
 
+	if interactive {
+		fmt.Printf("Created issue %d (%s)\n", *i.Number, *i.Title)
+	}
+
+	return *i.Number, nil
+}
+
+// NewIssue creates a template, parses the template and returns the Issue number if the user is in interactive mode
+func PopulateIssueInteractive(ctx context.Context, client *github.Client, settings *Settings, inputTitle, inputDescription string, labelSlice []string) (ir *github.IssueRequest, err error) {
+	labels, err := Labels(ctx, client, settings)
+	if err != nil {
+		return nil, err
+	}
+
 	tempFile, err := ioutil.TempFile("", "git-open-pull")
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	// fmt.Printf("drafting %s\n", tempFile.Name())
 	defer os.Remove(tempFile.Name())
+
+	if inputTitle != "" {
+		fmt.Fprintf(tempFile, "%s\n", inputTitle)
+	}
+	if inputDescription != "" {
+		fmt.Fprintf(tempFile, " * %s\n", inputDescription) 
+	}
 
 	// seed template with commit history
 	mergeBase, err := MergeBase(ctx, settings)
@@ -55,7 +102,7 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 			commits, err := Commits(ctx, mergeBase)
 			if err != nil {
 				log.Printf("error getting commits %s", err)
-			}
+			}  
 			for i, c := range commits {
 				// log.Printf("[%d] commit %s", i, c)
 				t, b, err := CommitDetails(ctx, c)
@@ -81,7 +128,22 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 	}
 	io.WriteString(tempFile, "\n# Uncomment to assign labels\n")
 	for _, l := range labels {
-		fmt.Fprintf(tempFile, "# Label: %s\n", l)
+		// if labels are passed as command line input, uncomment them
+		labelMatch := false
+		if labelSlice != nil {
+			for _, labelInput := range labelSlice {
+				if labelInput == l {
+					fmt.Fprintf(tempFile, "Label: %s\n", l)
+					labelMatch = true
+					break
+				}
+			}
+			if labelMatch == false {
+				fmt.Fprintf(tempFile, "# Label: %s\n", l)
+			}
+		} else {
+			fmt.Fprintf(tempFile, "# Label: %s\n", l)
+		}
 	}
 
 	io.WriteString(tempFile, `
@@ -100,7 +162,7 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("error running pre process template: %s:\n  %s", settings.PreProcess, out)
-			return 0, err
+			return nil, err
 		}
 	}
 
@@ -112,10 +174,10 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 	if err != nil {
 		tempFile.Close()
 		// os.Remove(tempFile.Name())
-		return 0, err
+		return nil, err
 	}
 	if cmd.ProcessState != nil && !cmd.ProcessState.Success() {
-		return 0, fmt.Errorf("non-zero exit code from editor")
+		return nil, fmt.Errorf("non-zero exit code from editor")
 	}
 
 	// post process template
@@ -124,14 +186,14 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("error running post process template: %s:\n  %s", settings.PostProcess, out)
-			return 0, err
+			return nil, err
 		}
 	}
 
 	// re-open the temp file
 	tempFile, err = os.Open(tempFile.Name())
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	var title string
@@ -154,13 +216,19 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 		}
 
 		if err := scanner.Err(); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
-	description := strings.TrimSpace(strings.Join(descriptions, "\n"))
+
+	var description string
+	if inputDescription != "" {
+		description = inputDescription
+	} else {
+		description = strings.TrimSpace(strings.Join(descriptions, "\n"))
+	}
 
 	if title == "" {
-		return 0, fmt.Errorf("missing title")
+		return nil, fmt.Errorf("missing title")
 	}
 
 	issue := &github.IssueRequest{
@@ -174,15 +242,7 @@ func NewIssue(ctx context.Context, client *github.Client, settings *Settings) (i
 		issue.Labels = &selectedLabels
 	}
 
-	i, _, err := client.Issues.Create(ctx, settings.BaseAccount, settings.BaseRepo, issue)
-	if err != nil {
-		return 0, err
-	}
-	fmt.Printf("Created issue %d (%s)\n", *i.Number, *i.Title)
-	if len(selectedLabels) > 0 {
-		fmt.Printf("\tLabels: %s\n", strings.Join(selectedLabels, ", "))
-	}
-	return *i.Number, nil
+	return issue, nil
 }
 
 // Labels returns all of the labels for a given repo


### PR DESCRIPTION
This PR adds functionality to git-open-pull to do the following:
1) pass a title via a --title flag
2) pass a description via a file path to --description
3) pass labels to a --labels flag
4) chose between interactive and non-interactive mode

An example of a non-interactive command is: git open-pull --description="description.txt" --title="My PR title" --labels="label1, lable2" --interactive=false
Interactive mode defaults to true so that current expected behavior continues as expected
